### PR TITLE
fix: Update function call to use WEBHOOK_SECRET()

### DIFF
--- a/src/app/api/webhook/route.js
+++ b/src/app/api/webhook/route.js
@@ -17,7 +17,7 @@ export async function POST(request) {
 		// check if the request come from lemonsqueezy servers #Security
 		const rawBody = await request.text()
 
-		const hmac = createHmac('sha256', WEBHOOK_SECRET)
+		const hmac = createHmac('sha256', WEBHOOK_SECRET())
 		const digest = Buffer.from(hmac.update(rawBody).digest('hex'), 'utf8')
 		const signature = Buffer.from(
 			request.headers.get('X-Signature') ?? '',


### PR DESCRIPTION
The function call for creating HMAC has been updated to correctly use the WEBHOOK_SECRET function.
