### PR TITLE
Fix: Correct several bugs and improve service logic

### DIFF
--- a/src/services/imageDescription.service.js
+++ b/src/services/imageDescription.service.js
@@ -111,7 +111,24 @@ export async function getImageDescription(base64Image, data) {
 			n: 1,
 		})
 
-		return JSON.parse(seoResponse.choices[0].message.content.trim())
+		try {
+			return JSON.parse(seoResponse.choices[0].message.content.trim())
+		} catch (jsonError) {
+			if (jsonError instanceof SyntaxError) {
+				console.error(
+					'Failed to parse JSON response from OpenAI: ',
+					jsonError.message
+				)
+				return {
+					error: 'Failed to parse SEO data',
+					title: '',
+					alt: '',
+					caption: '',
+				}
+			}
+			// Re-throw other errors to be caught by the outer catch block
+			throw jsonError
+		}
 	} catch (error) {
 		console.error('Failed to get image description:', error)
 		throw new Error('OpenAI service failure')


### PR DESCRIPTION
This commit addresses multiple issues across various services:

1.  **`database.service.js` (`syncPlans`):**
    *   Fixed an issue where `parseInt` on an empty or invalid price string would result in `NaN` being stored for a plan's price. The price now defaults to `0` in such cases.

2.  **`database.service.js` (`getSubscriptionFromUserId`):**
    *   Improved the function to reliably return the most relevant user subscription. It now orders subscriptions by status (active first), then by `renewsAt` (descending), and finally by `id` (descending) as a proxy for creation date.

3.  **`imageDescription.service.js` (`getImageDescription`):**
    *   Hardened JSON parsing for the SEO content response from OpenAI. If the response is invalid JSON, an error is logged, and a default error object is returned, preventing unhandled exceptions.

4.  **`webhook.service.js` (`processSubscriptionPaymentSuccess`):**
    *   Fixed potential null access errors when fetching plan details (`oldPlan`, `newPlan`, `currentSubscription.plan`). If a plan is not found or `packageSize` is missing, credits are defaulted to `0` for the affected part of the calculation, and an error is logged.
    *   Refactored the logic for identifying the user and subscription. The function now primarily uses the `lemonSqueezyId` from the webhook to fetch the `Subscription` record. This simplifies the logic for handling plan changes versus regular renewals and resolves potential ambiguities.
    *   Added checks for subscription existence and user ID matching between the webhook and subscription data.

Unit tests have been added or updated for all these changes to ensure correctness and prevent regressions.